### PR TITLE
Fix devOnly label placement

### DIFF
--- a/src/bin/generateMarkdown.ts
+++ b/src/bin/generateMarkdown.ts
@@ -44,7 +44,8 @@ function toMarkdownTable(section: string, group: EnvVarGroup): string {
     const rows = entries.map(([envar, entry]) => {
         const code = `settings.${section.toLowerCase()}.${entry.fieldName}`;
         const aliasCell = hasAlias ? ` ${entry.alias ?? ''} |` : '';
-        return `| ${(entry.devOnly ? '[dev only] ' : '') + envar + (entry.secret ? ' (secret)' : '')} |${aliasCell} ${code} | ${entry.type} | ${entry.default ?? ''} |`;
+        const typeCell = `${entry.type}${entry.devOnly ? ' [devOnly]' : ''}`;
+        return `| ${envar + (entry.secret ? ' (secret)' : '')} |${aliasCell} ${code} | ${typeCell} | ${entry.default ?? ''} |`;
     });
 
     const hasSecrets = entries.some(([, entry]) => entry.secret);

--- a/src/bin/listSettings.ts
+++ b/src/bin/listSettings.ts
@@ -20,10 +20,10 @@ export async function printSettings(): Promise<void> {
             if (typeof entry === 'object' && entry !== null) {
                 const code = `settings.${section.toLowerCase()}.${entry.fieldName}`;
                 const row = [
-                    (entry.devOnly ? '[dev only] ' : '') + envar + (entry.secret ? ' (secret)' : ''),
+                    envar + (entry.secret ? ' (secret)' : ''),
                     ...(hasAlias ? [entry.alias ?? ''] : []),
                     code,
-                    entry.type,
+                    entry.type + (entry.devOnly ? ' [devOnly]' : ''),
                     entry.default ?? ''
                 ];
                 rows.push(row);


### PR DESCRIPTION
## Summary
- move devOnly label to type column in `listSettings`
- move devOnly label to type column in `generateMarkdown`

## Testing
- `npm test` *(fails: Cannot find module './env-fixture.js')*

------
https://chatgpt.com/codex/tasks/task_e_6879665df4d8832ca80369a456bda36c