### PR TITLE
Handle devOnly in additional generators

### DIFF
--- a/src/bin/generateCompose.ts
+++ b/src/bin/generateCompose.ts
@@ -8,9 +8,9 @@ export async function writeComposeEnvFile(): Promise<string> {
         for (const [envar, entry] of Object.entries(group)) {
             if (envar.startsWith('_')) continue;
             if (typeof entry !== 'object' || entry === null || !('default' in entry)) continue;
-
             const name = entry.alias ?? envar;
-            const def = entry.default ?? `{${entry.type}}`;
+            const typeLabel = `${entry.type}${entry.devOnly ? ' [devOnly]' : ''}`;
+            const def = entry.default ?? `{${typeLabel}}`;
             lines.push(`  ${name}: ${def}`);
         }
     }

--- a/src/bin/generateDotEnv.ts
+++ b/src/bin/generateDotEnv.ts
@@ -16,7 +16,8 @@ export async function writeEnvFile(): Promise<void> {
       if (typeof entry !== 'object' || entry === null || !('default' in entry)) continue;
 
       const name = entry.alias ?? envar;
-      const def = entry.default ?? `{${entry.type}}`;
+      const typeLabel = `${entry.type}${entry.devOnly ? ' [devOnly]' : ''}`;
+      const def = entry.default ?? `{${typeLabel}}`;
       lines.push(`${name}=${def}`);
     }
 

--- a/src/bin/generateJson.ts
+++ b/src/bin/generateJson.ts
@@ -8,7 +8,6 @@ export async function generateJson(root: string | null = null, flat = false, use
     for (const [envar, meta] of Object.entries(vars)) {
       if (envar.startsWith('_')) continue;
       if (typeof meta !== 'object' || meta == null || !('default' in meta)) continue;
-
       let value: any;
 
       if (meta.default != null) {
@@ -46,7 +45,8 @@ export async function generateJson(root: string | null = null, flat = false, use
             value = meta.default;
         }
       } else {
-        value = `{${meta.type}}`;
+        const typeLabel = `${meta.type}${meta.devOnly ? ' [devOnly]' : ''}`;
+        value = `{${typeLabel}}`;
       }
 
       const outputKey = useCodeAsKey ? meta.fieldName : meta.alias ?? envar;

--- a/src/bin/generateK8s.ts
+++ b/src/bin/generateK8s.ts
@@ -9,7 +9,6 @@ export async function generateK8s(): Promise<string> {
     for (const [key, meta] of Object.entries(vars)) {
       if (key.startsWith('_')) continue;
       if (typeof meta !== 'object' || meta == null || !('default' in meta)) continue;
-
       const name = meta.alias ?? key;
       let rawValue: string;
 
@@ -43,7 +42,8 @@ export async function generateK8s(): Promise<string> {
             rawValue = meta.default; // Let YAML quote as needed
         }
       } else {
-        rawValue = `__PLACEHOLDER__{${meta.type}}__`; // marker for post-processing
+        const typeLabel = `${meta.type}${meta.devOnly ? ' [devOnly]' : ''}`;
+        rawValue = `__PLACEHOLDER__{${typeLabel}}__`; // marker for post-processing
       }
 
       envList.push({

--- a/src/bin/generateValues.ts
+++ b/src/bin/generateValues.ts
@@ -17,7 +17,8 @@ export async function writeValuesYaml(): Promise<void> {
     for (const [, entry] of entries) {
       if (typeof entry === 'object' && entry !== null) {
         const key = camelCase(entry.fieldName);
-        const value = entry.default ?? `{${entry.type}}`;
+        const typeLabel = `${entry.type}${entry.devOnly ? ' [devOnly]' : ''}`;
+        const value = entry.default ?? `{${typeLabel}}`;
         lines.push(`  ${key}: ${value}`);
       }
     }

--- a/src/bin/generateYaml.ts
+++ b/src/bin/generateYaml.ts
@@ -11,7 +11,6 @@ export async function generateYaml(root: string = 'settings', flat = false, useC
     for (const [envar, meta] of Object.entries(vars)) {
       if (envar.startsWith('_')) continue;
       if (typeof meta !== 'object' || meta == null || !('default' in meta)) continue;
-
       const yamlKey = useCodeAsKey ? meta.fieldName : meta.alias ?? envar;
       let value: any;
 
@@ -50,7 +49,8 @@ export async function generateYaml(root: string = 'settings', flat = false, useC
             value = meta.default;
         }
       } else {
-        value = `-{-${meta.type}-}-`;
+        const typeLabel = `${meta.type}${meta.devOnly ? ' [devOnly]' : ''}`;
+        value = `-{-${typeLabel}-}-`;
       }
 
       if (flat) {


### PR DESCRIPTION
## Summary
- annotate devOnly variables in env, compose, values, json, yaml, and k8s outputs

## Testing
- `npm test` *(fails: Cannot find module './env-fixture.js')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68796a867160832ca39f724b4bb17957