### PR TITLE
Improve annotation display

### DIFF
--- a/src/bin/formatType.ts
+++ b/src/bin/formatType.ts
@@ -1,0 +1,13 @@
+export function formatType(type: string, devOnly: boolean): string {
+  const annotations: string[] = [];
+  let clean = type.replace(/\s*\[(pattern|optional)\]/g, (_, a) => {
+    annotations.push(a);
+    return '';
+  });
+  clean = clean.replace(/\s+/g, ' ').trim();
+  if (devOnly) annotations.push('devOnly');
+  if (annotations.length > 0) {
+    return `${clean} [${annotations.join(', ')}]`;
+  }
+  return clean;
+}

--- a/src/bin/generateCompose.ts
+++ b/src/bin/generateCompose.ts
@@ -1,4 +1,5 @@
 import { extractEnvSpec } from './extractEnvSpec.js';
+import { formatType } from './formatType.js';
 
 export async function writeComposeEnvFile(): Promise<string> {
     const spec = await extractEnvSpec();
@@ -9,7 +10,7 @@ export async function writeComposeEnvFile(): Promise<string> {
             if (envar.startsWith('_')) continue;
             if (typeof entry !== 'object' || entry === null || !('default' in entry)) continue;
             const name = entry.alias ?? envar;
-            const typeLabel = `${entry.type}${entry.devOnly ? ' [devOnly]' : ''}`;
+            const typeLabel = formatType(entry.type, entry.devOnly);
             const def = entry.default ?? `{${typeLabel}}`;
             lines.push(`  ${name}: ${def}`);
         }

--- a/src/bin/generateDotEnv.ts
+++ b/src/bin/generateDotEnv.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { extractEnvSpec } from './extractEnvSpec.js';
+import { formatType } from './formatType.js';
 import { PROJECT_ROOT } from '../lib/paths.js';
 
 const envFilename = '.env.template';
@@ -16,7 +17,7 @@ export async function writeEnvFile(): Promise<void> {
       if (typeof entry !== 'object' || entry === null || !('default' in entry)) continue;
 
       const name = entry.alias ?? envar;
-      const typeLabel = `${entry.type}${entry.devOnly ? ' [devOnly]' : ''}`;
+      const typeLabel = formatType(entry.type, entry.devOnly);
       const def = entry.default ?? `{${typeLabel}}`;
       lines.push(`${name}=${def}`);
     }

--- a/src/bin/generateJson.ts
+++ b/src/bin/generateJson.ts
@@ -1,4 +1,5 @@
 import { extractEnvSpec } from './extractEnvSpec.js';
+import { formatType } from './formatType.js';
 
 export async function generateJson(root: string | null = null, flat = false, useCodeAsKey = false): Promise<string> {
   const spec = await extractEnvSpec();
@@ -45,7 +46,7 @@ export async function generateJson(root: string | null = null, flat = false, use
             value = meta.default;
         }
       } else {
-        const typeLabel = `${meta.type}${meta.devOnly ? ' [devOnly]' : ''}`;
+        const typeLabel = formatType(meta.type, meta.devOnly);
         value = `{${typeLabel}}`;
       }
 

--- a/src/bin/generateK8s.ts
+++ b/src/bin/generateK8s.ts
@@ -1,5 +1,6 @@
 import yaml from 'yaml';
 import { extractEnvSpec } from './extractEnvSpec.js';
+import { formatType } from './formatType.js';
 
 export async function generateK8s(): Promise<string> {
   const spec = await extractEnvSpec();
@@ -42,7 +43,7 @@ export async function generateK8s(): Promise<string> {
             rawValue = meta.default; // Let YAML quote as needed
         }
       } else {
-        const typeLabel = `${meta.type}${meta.devOnly ? ' [devOnly]' : ''}`;
+        const typeLabel = formatType(meta.type, meta.devOnly);
         rawValue = `__PLACEHOLDER__{${typeLabel}}__`; // marker for post-processing
       }
 

--- a/src/bin/generateMarkdown.ts
+++ b/src/bin/generateMarkdown.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { extractEnvSpec } from './extractEnvSpec.js';
+import { formatType } from './formatType.js';
 import { PROJECT_ROOT } from '../lib/paths.js';
 
 const OUTPUT_FILE = path.join(PROJECT_ROOT, 'SETTINGS.md');
@@ -44,7 +45,7 @@ function toMarkdownTable(section: string, group: EnvVarGroup): string {
     const rows = entries.map(([envar, entry]) => {
         const code = `settings.${section.toLowerCase()}.${entry.fieldName}`;
         const aliasCell = hasAlias ? ` ${entry.alias ?? ''} |` : '';
-        const typeCell = `${entry.type}${entry.devOnly ? ' [devOnly]' : ''}`;
+        const typeCell = formatType(entry.type, entry.devOnly);
         return `| ${envar + (entry.secret ? ' (secret)' : '')} |${aliasCell} ${code} | ${typeCell} | ${entry.default ?? ''} |`;
     });
 

--- a/src/bin/generateValues.ts
+++ b/src/bin/generateValues.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { camelCase } from 'change-case';
 import { extractEnvSpec } from './extractEnvSpec.js';
+import { formatType } from './formatType.js';
 import { PROJECT_ROOT } from '../lib/paths.js';
 
 const OUTPUT_FILE = path.join(PROJECT_ROOT, 'values.yaml');
@@ -17,7 +18,7 @@ export async function writeValuesYaml(): Promise<void> {
     for (const [, entry] of entries) {
       if (typeof entry === 'object' && entry !== null) {
         const key = camelCase(entry.fieldName);
-        const typeLabel = `${entry.type}${entry.devOnly ? ' [devOnly]' : ''}`;
+        const typeLabel = formatType(entry.type, entry.devOnly);
         const value = entry.default ?? `{${typeLabel}}`;
         lines.push(`  ${key}: ${value}`);
       }

--- a/src/bin/generateYaml.ts
+++ b/src/bin/generateYaml.ts
@@ -1,5 +1,6 @@
 // bin/generateYaml.ts
 import { extractEnvSpec } from './extractEnvSpec.js';
+import { formatType } from './formatType.js';
 import yaml from 'yaml';
 
 export async function generateYaml(root: string = 'settings', flat = false, useCodeAsKey = false): Promise<string> {
@@ -49,7 +50,7 @@ export async function generateYaml(root: string = 'settings', flat = false, useC
             value = meta.default;
         }
       } else {
-        const typeLabel = `${meta.type}${meta.devOnly ? ' [devOnly]' : ''}`;
+        const typeLabel = formatType(meta.type, meta.devOnly);
         value = `-{-${typeLabel}-}-`;
       }
 

--- a/src/bin/listSettings.ts
+++ b/src/bin/listSettings.ts
@@ -1,4 +1,5 @@
 import { extractEnvSpec } from './extractEnvSpec.js';
+import { formatType } from './formatType.js';
 
 function padRight(value: string, width: number): string {
     return value + ' '.repeat(width - value.length);
@@ -23,7 +24,7 @@ export async function printSettings(): Promise<void> {
                     envar + (entry.secret ? ' (secret)' : ''),
                     ...(hasAlias ? [entry.alias ?? ''] : []),
                     code,
-                    entry.type + (entry.devOnly ? ' [devOnly]' : ''),
+                    formatType(entry.type, entry.devOnly),
                     entry.default ?? ''
                 ];
                 rows.push(row);


### PR DESCRIPTION
## Summary
- consolidate annotation formatting with `formatType`
- apply new formatting to CLI generators

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687971a4ee58832c9705dcfb866564f0