### PR TITLE
Add optional flag to env spec and update formatType

### DIFF
--- a/src/bin/formatType.ts
+++ b/src/bin/formatType.ts
@@ -1,13 +1,15 @@
-export function formatType(type: string, devOnly: boolean): string {
+export interface TypeInfo {
+  type: string;
+  devOnly: boolean;
+  optional?: boolean;
+  pattern?: string | null;
+}
+
+export function formatType(info: TypeInfo): string {
   const annotations: string[] = [];
-  let clean = type.replace(/\s*\[(pattern|optional)\]/g, (_, a) => {
-    annotations.push(a);
-    return '';
-  });
-  clean = clean.replace(/\s+/g, ' ').trim();
-  if (devOnly) annotations.push('devOnly');
-  if (annotations.length > 0) {
-    return `${clean} [${annotations.join(', ')}]`;
-  }
-  return clean;
+  const clean = info.type.replace(/\s+/g, ' ').trim();
+  if (info.optional) annotations.push('optional');
+  if (info.pattern) annotations.push('pattern');
+  if (info.devOnly) annotations.push('devOnly');
+  return annotations.length > 0 ? `${clean} [${annotations.join(', ')}]` : clean;
 }

--- a/src/bin/generateCompose.ts
+++ b/src/bin/generateCompose.ts
@@ -10,7 +10,7 @@ export async function writeComposeEnvFile(): Promise<string> {
             if (envar.startsWith('_')) continue;
             if (typeof entry !== 'object' || entry === null || !('default' in entry)) continue;
             const name = entry.alias ?? envar;
-            const typeLabel = formatType(entry.type, entry.devOnly);
+            const typeLabel = formatType(entry);
             const def = entry.default ?? `{${typeLabel}}`;
             lines.push(`  ${name}: ${def}`);
         }

--- a/src/bin/generateDotEnv.ts
+++ b/src/bin/generateDotEnv.ts
@@ -17,7 +17,7 @@ export async function writeEnvFile(): Promise<void> {
       if (typeof entry !== 'object' || entry === null || !('default' in entry)) continue;
 
       const name = entry.alias ?? envar;
-      const typeLabel = formatType(entry.type, entry.devOnly);
+      const typeLabel = formatType(entry);
       const def = entry.default ?? `{${typeLabel}}`;
       lines.push(`${name}=${def}`);
     }

--- a/src/bin/generateJson.ts
+++ b/src/bin/generateJson.ts
@@ -46,7 +46,7 @@ export async function generateJson(root: string | null = null, flat = false, use
             value = meta.default;
         }
       } else {
-        const typeLabel = formatType(meta.type, meta.devOnly);
+        const typeLabel = formatType(meta);
         value = `{${typeLabel}}`;
       }
 

--- a/src/bin/generateK8s.ts
+++ b/src/bin/generateK8s.ts
@@ -43,7 +43,7 @@ export async function generateK8s(): Promise<string> {
             rawValue = meta.default; // Let YAML quote as needed
         }
       } else {
-        const typeLabel = formatType(meta.type, meta.devOnly);
+        const typeLabel = formatType(meta);
         rawValue = `__PLACEHOLDER__{${typeLabel}}__`; // marker for post-processing
       }
 

--- a/src/bin/generateMarkdown.ts
+++ b/src/bin/generateMarkdown.ts
@@ -11,6 +11,7 @@ type EnvVarSpec = {
     fieldName: string;
     secret: boolean;
     devOnly: boolean;
+    optional: boolean;
     type: string;
     description?: string | null;
     pattern?: string | null;
@@ -45,7 +46,7 @@ function toMarkdownTable(section: string, group: EnvVarGroup): string {
     const rows = entries.map(([envar, entry]) => {
         const code = `settings.${section.toLowerCase()}.${entry.fieldName}`;
         const aliasCell = hasAlias ? ` ${entry.alias ?? ''} |` : '';
-        const typeCell = formatType(entry.type, entry.devOnly);
+        const typeCell = formatType(entry);
         return `| ${envar + (entry.secret ? ' (secret)' : '')} |${aliasCell} ${code} | ${typeCell} | ${entry.default ?? ''} |`;
     });
 

--- a/src/bin/generateValues.ts
+++ b/src/bin/generateValues.ts
@@ -18,7 +18,7 @@ export async function writeValuesYaml(): Promise<void> {
     for (const [, entry] of entries) {
       if (typeof entry === 'object' && entry !== null) {
         const key = camelCase(entry.fieldName);
-        const typeLabel = formatType(entry.type, entry.devOnly);
+        const typeLabel = formatType(entry);
         const value = entry.default ?? `{${typeLabel}}`;
         lines.push(`  ${key}: ${value}`);
       }

--- a/src/bin/generateYaml.ts
+++ b/src/bin/generateYaml.ts
@@ -50,7 +50,7 @@ export async function generateYaml(root: string = 'settings', flat = false, useC
             value = meta.default;
         }
       } else {
-        const typeLabel = formatType(meta.type, meta.devOnly);
+        const typeLabel = formatType(meta);
         value = `-{-${typeLabel}-}-`;
       }
 

--- a/src/bin/listSettings.ts
+++ b/src/bin/listSettings.ts
@@ -24,7 +24,7 @@ export async function printSettings(): Promise<void> {
                     envar + (entry.secret ? ' (secret)' : ''),
                     ...(hasAlias ? [entry.alias ?? ''] : []),
                     code,
-                    formatType(entry.type, entry.devOnly),
+                    formatType(entry),
                     entry.default ?? ''
                 ];
                 rows.push(row);


### PR DESCRIPTION
## Summary
- add `optional` property to env spec entries
- no longer include `[optional]` or `[pattern]` in type strings
- update `formatType` to build annotations from the env spec entry
- adjust scripts to use the new `formatType` signature

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68797596e018832c896ac62bf5eaac5a