### PR TITLE
Add --skip-dev flag to envarna CLI

### DIFF
--- a/src/bin/envarna.ts
+++ b/src/bin/envarna.ts
@@ -26,25 +26,30 @@ const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
 yargs(hideBin(process.argv))
   .version(pkg.version)
   .scriptName('envarna')
+  .option('skip-dev', {
+    type: 'boolean',
+    default: false,
+    describe: 'Exclude fields marked @devOnly',
+  })
 
-  .command('list', 'Display settings details', () => {}, async () => {
-    await printSettings()
+  .command('list', 'Display settings details', () => {}, async argv => {
+    await printSettings(argv.skipDev as boolean)
   })
-  .command('env', 'Write ".env.template"', () => {}, async () => {
-    await writeEnvFile()
+  .command('env', 'Write ".env.template"', () => {}, async argv => {
+    await writeEnvFile(argv.skipDev as boolean)
   })
-  .command('md', 'Write "SETTINGS.md"', () => {}, async () => {
-    await writeSettingsMarkdown()
+  .command('md', 'Write "SETTINGS.md"', () => {}, async argv => {
+    await writeSettingsMarkdown(argv.skipDev as boolean)
   })
-  .command('values', 'Write "values.yaml"', () => {}, async () => {
-    await writeValuesYaml()
+  .command('values', 'Write "values.yaml"', () => {}, async argv => {
+    await writeValuesYaml(argv.skipDev as boolean)
   })
-  .command('compose', 'Display docker-compose style environment yaml', () => {}, async () => {
-    const output = await writeComposeEnvFile();
+  .command('compose', 'Display docker-compose style environment yaml', () => {}, async argv => {
+    const output = await writeComposeEnvFile(argv.skipDev as boolean);
     console.log(output);
   })
-  .command('k8s', 'Display kubernetes style env var structure', () => {}, async () => {
-      const output = await generateK8s();
+  .command('k8s', 'Display kubernetes style env var structure', () => {}, async argv => {
+      const output = await generateK8s(argv.skipDev as boolean);
       console.log(output);
     }
   )
@@ -67,7 +72,7 @@ yargs(hideBin(process.argv))
       default: false,
     }),
     async argv => {
-      const output = await generateJson(argv.root ?? null, argv.flat, argv.code);
+      const output = await generateJson(argv.root ?? null, argv.flat, argv.code, argv.skipDev as boolean);
       console.log(output);
     }
   )
@@ -90,12 +95,12 @@ yargs(hideBin(process.argv))
         default: false,
     }),
     async argv => {
-      const output = await generateYaml(argv.root, argv.flat, argv.code);
+      const output = await generateYaml(argv.root, argv.flat, argv.code, argv.skipDev as boolean);
       console.log(output);
     }
   )
-  .command('raw', 'Display the raw structure extracted from the settings classes used to power the other formats', () => {}, async () => {
-    const output = await writeRawEnvSpec();
+  .command('raw', 'Display the raw structure extracted from the settings classes used to power the other formats', () => {}, async argv => {
+    const output = await writeRawEnvSpec(argv.skipDev as boolean);
     console.log(output);
   })
   .demandCommand()

--- a/src/bin/extractEnvSpec.ts
+++ b/src/bin/extractEnvSpec.ts
@@ -56,7 +56,10 @@ function findBaseCallName(expr: Expression): string | null {
   return null;
 }
 
-export async function extractEnvSpec(scanDir = PROJECT_ROOT): Promise<EnvSpec> {
+export async function extractEnvSpec(
+  scanDir: string = PROJECT_ROOT,
+  skipDev: boolean = false
+): Promise<EnvSpec> {
   const project = new Project({
     tsConfigFilePath: path.resolve(PROJECT_ROOT, 'tsconfig.json'),
   });
@@ -119,6 +122,7 @@ export async function extractEnvSpec(scanDir = PROJECT_ROOT): Promise<EnvSpec> {
         const decorators = prop.getDecorators();
         const isSecret = decorators.some(d => d.getName() === 'secret');
         const isDevOnly = decorators.some(d => d.getName() === 'devOnly');
+        if (skipDev && isDevOnly) continue;
         const fieldComment = prop.getJsDocs()[0]?.getComment();
         const description = fieldComment != null ? String(fieldComment) : null;
 

--- a/src/bin/generateCompose.ts
+++ b/src/bin/generateCompose.ts
@@ -1,8 +1,8 @@
 import { extractEnvSpec } from './extractEnvSpec.js';
 import { formatType } from './formatType.js';
 
-export async function writeComposeEnvFile(): Promise<string> {
-    const spec = await extractEnvSpec();
+export async function writeComposeEnvFile(skipDev = false): Promise<string> {
+    const spec = await extractEnvSpec(undefined, skipDev);
 
     const lines: string[] = ['environment:'];
     for (const [, group] of Object.entries(spec)) {

--- a/src/bin/generateDotEnv.ts
+++ b/src/bin/generateDotEnv.ts
@@ -7,8 +7,8 @@ import { PROJECT_ROOT } from '../lib/paths.js';
 const envFilename = '.env.template';
 const OUTPUT_FILE = path.join(PROJECT_ROOT, envFilename);
 
-export async function writeEnvFile(): Promise<void> {
-  const spec = await extractEnvSpec();
+export async function writeEnvFile(skipDev = false): Promise<void> {
+  const spec = await extractEnvSpec(undefined, skipDev);
 
   const lines: string[] = [];
   for (const [, group] of Object.entries(spec)) {

--- a/src/bin/generateJson.ts
+++ b/src/bin/generateJson.ts
@@ -1,8 +1,13 @@
 import { extractEnvSpec } from './extractEnvSpec.js';
 import { formatType } from './formatType.js';
 
-export async function generateJson(root: string | null = null, flat = false, useCodeAsKey = false): Promise<string> {
-  const spec = await extractEnvSpec();
+export async function generateJson(
+  root: string | null = null,
+  flat = false,
+  useCodeAsKey = false,
+  skipDev = false
+): Promise<string> {
+  const spec = await extractEnvSpec(undefined, skipDev);
   const output: any = root ? { [root]: {} } : {};
 
   for (const [group, vars] of Object.entries(spec)) {

--- a/src/bin/generateK8s.ts
+++ b/src/bin/generateK8s.ts
@@ -2,8 +2,8 @@ import yaml from 'yaml';
 import { extractEnvSpec } from './extractEnvSpec.js';
 import { formatType } from './formatType.js';
 
-export async function generateK8s(): Promise<string> {
-  const spec = await extractEnvSpec();
+export async function generateK8s(skipDev = false): Promise<string> {
+  const spec = await extractEnvSpec(undefined, skipDev);
   const envList: { name: string; value: any }[] = [];
 
   for (const vars of Object.values(spec)) {

--- a/src/bin/generateMarkdown.ts
+++ b/src/bin/generateMarkdown.ts
@@ -69,8 +69,8 @@ function toMarkdownTable(section: string, group: EnvVarGroup): string {
     return `${sectionHeader}${secretsLine}${descriptionLine}\n${header}\n${rows.join('\n')}${extras}`;
 }
 
-export async function writeSettingsMarkdown(): Promise<void> {
-    const spec = await extractEnvSpec();
+export async function writeSettingsMarkdown(skipDev = false): Promise<void> {
+    const spec = await extractEnvSpec(undefined, skipDev);
     const sections = Object.entries(spec)
         .map(([section, group]) => toMarkdownTable(section, group))
         .join('\n\n');

--- a/src/bin/generateRaw.ts
+++ b/src/bin/generateRaw.ts
@@ -1,7 +1,7 @@
 import { extractEnvSpec } from './extractEnvSpec.js';
 
-export async function writeRawEnvSpec(): Promise<string> {
-    const spec = await extractEnvSpec();
+export async function writeRawEnvSpec(skipDev = false): Promise<string> {
+    const spec = await extractEnvSpec(undefined, skipDev);
 
     return JSON.stringify(spec, null, 2);
 }

--- a/src/bin/generateValues.ts
+++ b/src/bin/generateValues.ts
@@ -7,8 +7,8 @@ import { PROJECT_ROOT } from '../lib/paths.js';
 
 const OUTPUT_FILE = path.join(PROJECT_ROOT, 'values.yaml');
 
-export async function writeValuesYaml(): Promise<void> {
-  const spec = await extractEnvSpec();
+export async function writeValuesYaml(skipDev = false): Promise<void> {
+  const spec = await extractEnvSpec(undefined, skipDev);
   const lines: string[] = [];
 
   for (const [section, group] of Object.entries(spec)) {

--- a/src/bin/generateYaml.ts
+++ b/src/bin/generateYaml.ts
@@ -3,8 +3,13 @@ import { extractEnvSpec } from './extractEnvSpec.js';
 import { formatType } from './formatType.js';
 import yaml from 'yaml';
 
-export async function generateYaml(root: string = 'settings', flat = false, useCodeAsKey = false): Promise<string> {
-  const spec = await extractEnvSpec();
+export async function generateYaml(
+  root: string = 'settings',
+  flat = false,
+  useCodeAsKey = false,
+  skipDev = false
+): Promise<string> {
+  const spec = await extractEnvSpec(undefined, skipDev);
   const output: Record<string, any> = {};
   output[root] = {};
 

--- a/src/bin/listSettings.ts
+++ b/src/bin/listSettings.ts
@@ -5,8 +5,8 @@ function padRight(value: string, width: number): string {
     return value + ' '.repeat(width - value.length);
 }
 
-export async function printSettings(): Promise<void> {
-    const spec = await extractEnvSpec();
+export async function printSettings(skipDev = false): Promise<void> {
+    const spec = await extractEnvSpec(undefined, skipDev);
 
     for (const [section, group] of Object.entries(spec)) {
         const entries = Object.entries(group).filter(([k]) => k !== '_description' && k !== '_hasAlias');

--- a/src/doc-generator/src/how-to/command-line.md
+++ b/src/doc-generator/src/how-to/command-line.md
@@ -24,6 +24,7 @@ Commands:
 
 Options:
   --version  Show version number                                       [boolean]
+  --skip-dev  Exclude fields marked @devOnly                            [boolean]
   --help     Show help                                                 [boolean]
 ```
 


### PR DESCRIPTION
## Summary
- add `--skip-dev` global CLI option
- pass `skipDev` flag to all generator functions
- filter dev-only fields in `extractEnvSpec`
- update command line documentation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68797c89bfbc832c93234ef9d34fab33