### PR TITLE
Fix async loader BDD test

### DIFF
--- a/features/async-loader.feature
+++ b/features/async-loader.feature
@@ -5,4 +5,4 @@ Feature: can load settings values from async sources, e.g. secrets manager
     And the environment variable "DB_CONNECTION_STRING" is set to "connection-from-env"
     And the environment variable "DB_NAME" is set to "name-from-env"
     When I initialize settings
-    Then the setting "connectionString" key's value is "mongodb://secret-uri"
+    Then the setting "db.connectionString" key's value is "mongodb://secret-uri"

--- a/tests/async-loader.steps.ts
+++ b/tests/async-loader.steps.ts
@@ -54,5 +54,10 @@ When('I initialize settings', async function (this: LoaderWorld) {
 });
 
 Then("the setting {string} key's value is {string}", async function (this: LoaderWorld, key: string, expected: string) {
-  expect(this.settings[key]).to.eq(expected);
+  const parts = key.split('.')
+  let current: any = this.settings
+  for (const part of parts) {
+    current = current[part]
+  }
+  expect(current).to.eq(expected);
 });


### PR DESCRIPTION
## Summary
- correct feature to access the `db` settings object
- resolve step definition to handle nested keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bc5d077ac832cbac6a3f7d7adbbc0